### PR TITLE
[Website] - [Date Input Example]: Remove extra class attribute from date input example

### DIFF
--- a/_includes/code/components/date-input.html
+++ b/_includes/code/components/date-input.html
@@ -5,15 +5,15 @@
   <div class="usa-date-of-birth">
     <div class="usa-form-group usa-form-group-month">
       <label for="date_of_birth_1">Month</label>
-      <input class="usa-input-inline" aria-describedby="dobHint" class="usa-form-control" id="date_of_birth_1" name="date_of_birth_1" pattern="0?[1-9]|1[012]" type="number" min="1" max="12" value="">
+      <input class="usa-input-inline" aria-describedby="dobHint" id="date_of_birth_1" name="date_of_birth_1" pattern="0?[1-9]|1[012]" type="number" min="1" max="12" value="">
     </div>
     <div class="usa-form-group usa-form-group-day">
       <label for="date_of_birth_2">Day</label>
-      <input class="usa-input-inline" aria-describedby="dobHint" class="usa-form-control" id="date_of_birth_2" name="date_of_birth_2" pattern="0?[1-9]|1[0-9]|2[0-9]|3[01]" type="number" min="1" max="31" value="">
+      <input class="usa-input-inline" aria-describedby="dobHint" id="date_of_birth_2" name="date_of_birth_2" pattern="0?[1-9]|1[0-9]|2[0-9]|3[01]" type="number" min="1" max="31" value="">
     </div>
     <div class="usa-form-group usa-form-group-year">
       <label for="date_of_birth_3">Year</label>
-      <input class="usa-input-inline" aria-describedby="dobHint" class="usa-form-control" id="date_of_birth_3" name="date_of_birth_3" pattern="[0-9]{4}" type="number" min="1900" max="2000" value="">
+      <input class="usa-input-inline" aria-describedby="dobHint" id="date_of_birth_3" name="date_of_birth_3" pattern="[0-9]{4}" type="number" min="1900" max="2000" value="">
     </div>
   </div>
 </fieldset>


### PR DESCRIPTION
## Description
Example for Date Input used elements that contained multiple `class` attributes. Removed second `class` attribute that appeared to reference a non-existent CSS selector.
